### PR TITLE
Desabilita metricas de AbcSize e OpenStructUse

### DIFF
--- a/rubocop-main.yml
+++ b/rubocop-main.yml
@@ -29,6 +29,9 @@ Layout/LineLength:
 Style/Documentation:
   Enabled: false
 
+Metrics/AbcSize:
+  Enabled: false
+
 Metrics/BlockLength:
   Enabled: false
 
@@ -48,6 +51,9 @@ RSpec/MultipleExpectations:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/OpenStructUse:
   Enabled: false
 
 # Enable rules


### PR DESCRIPTION
## O que foi implementado

 - Sugestão para desabilitar as metricas de AbcSize de OpenStructUse no rubocop