### PR TITLE
Desabilita o Metrics/ClassLength do rubocop

### DIFF
--- a/.rubocop-main.yml
+++ b/.rubocop-main.yml
@@ -35,6 +35,9 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Enabled: false
 
+Metrics/ClassLength:
+  Enabled: false
+
 Metrics/MethodLength:
   Enabled: false
 


### PR DESCRIPTION
- Desabilita Metrics/ClassLength do rubocop