### PR TITLE
Adjust DynamicFindBy cop

### DIFF
--- a/.rubocop-main.yml
+++ b/.rubocop-main.yml
@@ -6,6 +6,10 @@ require:
 Rails:
   Enabled: true
 
+Rails/DynamicFindBy:
+  Exclude:
+  - spec/layers/infra/repositories/*
+
 AllCops:
   TargetRubyVersion: 2.6.5
   TargetRailsVersion: 6.1


### PR DESCRIPTION
Exclui as pastas de testes de repositórios da regra `DynamicFindBy`, pois criamos métodos find_by_* que não são os métodos dinâmicos que o cop verifica.