### PR TITLE
Disable dynamicfindby cop

### DIFF
--- a/.rubocop-main.yml
+++ b/.rubocop-main.yml
@@ -7,8 +7,7 @@ Rails:
   Enabled: true
 
 Rails/DynamicFindBy:
-  Exclude:
-  - spec/layers/infra/repositories/*
+  Enabled: false
 
 AllCops:
   TargetRubyVersion: 2.6.5


### PR DESCRIPTION
Desabilita o `DynamicFindBy` cop, já que utilizamos repositorios que utilizamnomes semelhantes ao que o cop verifica.