### PR TITLE
rubocop:enable Rails/ResponseParsedBody

### DIFF
--- a/.rubocop-main.yml
+++ b/.rubocop-main.yml
@@ -66,9 +66,8 @@ Style/FrozenStringLiteralComment:
 Style/OpenStructUse:
   Enabled: false
 
-Rails:
-  ResponseParsedBody:
-    Enabled: false
+Rails/ResponseParsedBody:
+  Enabled: false
 
 # Enable rules
 

--- a/.rubocop-main.yml
+++ b/.rubocop-main.yml
@@ -66,6 +66,10 @@ Style/FrozenStringLiteralComment:
 Style/OpenStructUse:
   Enabled: false
 
+Rails:
+  ResponseParsedBody:
+    Enabled: false
+
 # Enable rules
 
 Lint/MissingSuper:


### PR DESCRIPTION
Quando usamos `parsed_body`, mesmo com `content_type: application/json`, o pagnet está retornando uma string, e não o json.
Por esse motivo, a grande maioria dos testes do pagnet ignoram esse erro, e precisamos ficar manualmente revertendo caso a caso quando utilizamos o Cursor ou o Rubocop para corrigir o estilo do código.

![image](https://github.com/user-attachments/assets/c7294b56-5461-4306-9bb2-48736e0a2916)

Por esse motivo, este PR remove essa regra, para evitar ignorar este erro.